### PR TITLE
FIX CONDITION ON CV_MINOR_VERSION IN aruco_detect.cpp

### DIFF
--- a/src/aruco_detect.cpp
+++ b/src/aruco_detect.cpp
@@ -444,7 +444,7 @@ void FiducialsNode::configCallback(aruco_detect::DetectorParamsConfig & config, 
     detectorParams->cornerRefinementMaxIterations = config.cornerRefinementMaxIterations;
     detectorParams->cornerRefinementMinAccuracy = config.cornerRefinementMinAccuracy;
     detectorParams->cornerRefinementWinSize = config.cornerRefinementWinSize;
-#if CV_MINOR_VERSION==2
+#if CV_MAJOR_VERSION==3 && CV_MINOR_VERSION==2
     detectorParams->doCornerRefinement = config.doCornerRefinement;
 #else
     if (config.doCornerRefinement) {
@@ -797,7 +797,7 @@ FiducialsNode::FiducialsNode() : nh(), pnh("~"), it(nh)
     pnh.param<int>("cornerRefinementMaxIterations", detectorParams->cornerRefinementMaxIterations, 30);
     pnh.param<double>("cornerRefinementMinAccuracy", detectorParams->cornerRefinementMinAccuracy, 0.01); /* default 0.1 */
     pnh.param<int>("cornerRefinementWinSize", detectorParams->cornerRefinementWinSize, 5);
-#if CV_MINOR_VERSION==2
+#if CV_MAJOR_VERSION==3 && CV_MINOR_VERSION==2
     pnh.param<bool>("doCornerRefinement",detectorParams->doCornerRefinement, true); /* default false */
 #else
     bool doCornerRefinement = true;


### PR DESCRIPTION
#### Issues
Closes #1 

#### Implementation Details
Lines 447 and 800 in aruco_detect.cpp checked CV_MINOR_VERSION to access the correct member functions of detectorParams. With CV_MAJOR_VERSION 4, a conidtional check on the CV_MINOR_VERSION introduced make errors with OpenCV 4.2.0. Conditions on both CV_MINOR_VERSION and CV_MAJOR_VERSION fixes the make error.